### PR TITLE
WIP: Initial import and azure hostname module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# afterburn-dracut for Fedora/RHEL CoreOS systems
+
+This repo holds custom dracut modules required by CoreOS systems to extend cloud-provider support in the initramfs.
+
+This is packaged together with [Afterburn][afterburn].
+
+[afterburn]: https://github.com/coreos/afterburn

--- a/dracut/30afterburn/azure-hostname.service
+++ b/dracut/30afterburn/azure-hostname.service
@@ -10,7 +10,6 @@ Before=ignition-setup.service
 [Service]
 ExecStart=/usr/bin/afterburn --cmdline --hostname /etc/hostname
 Type=oneshot
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/dracut/30afterburn/azure-hostname.service
+++ b/dracut/30afterburn/azure-hostname.service
@@ -1,0 +1,16 @@
+# Azure needs to fetch hostname from metadata
+# during the initramfs
+
+[Unit]
+Description=Afterburn hostname
+ConditionKernelCommandLine=|ignition.platform.id=azure
+ConditionFirstBoot=yes
+Before=ignition-setup.service
+
+[Service]
+ExecStart=/usr/bin/afterburn --cmdline --hostname /etc/hostname
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/dracut/30afterburn/azure-hostname.service
+++ b/dracut/30afterburn/azure-hostname.service
@@ -4,12 +4,12 @@
 [Unit]
 Description=Afterburn hostname
 ConditionKernelCommandLine=|ignition.platform.id=azure
-ConditionFirstBoot=yes
-Before=ignition-setup.service
+After=ignition-disks.service
+Before=ignition-files.service
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
-ExecStart=/usr/bin/afterburn --cmdline --hostname /etc/hostname
+ExecStart=/usr/bin/afterburn --cmdline --hostname=/sysroot/etc/hostname
 Type=oneshot
-
-[Install]
-WantedBy=multi-user.target

--- a/dracut/30afterburn/module-setup.sh
+++ b/dracut/30afterburn/module-setup.sh
@@ -2,6 +2,10 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+check() {
+    return 0
+}
+
 depends() {
     echo systemd network
 }
@@ -11,4 +15,13 @@ install() {
 
     inst_simple "$moddir/azure-hostname.service" \
         "$systemdutildir/system/azure-hostname.service"
+
+    mkdir -p "$initdir/$systemdsystemunitdir/initrd.target.requires"
+
+    ln -s "../azure-hostname.service" "$initdir/$systemdsystemunitdir/initrd.target.requires/azure-hostname.service"
+
+    inst_simple "$moddir/test-metal.service" \
+        "$systemdutildir/system/test-metal.service"
+
+    ln -s "../test-metal.service" "$initdir/$systemdsystemunitdir/initrd.target.requires/test-metal.service"
 }

--- a/dracut/30afterburn/module-setup.sh
+++ b/dracut/30afterburn/module-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo systemd network
+}
+
+install() {
+    inst_multiple afterburn
+
+    inst_simple "$moddir/azure-hostname.service" \
+        "$systemdutildir/system/azure-hostname.service"
+}

--- a/dracut/30afterburn/test-metal.service
+++ b/dracut/30afterburn/test-metal.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Afterburn hostname test
+ConditionKernelCommandLine=|ignition.platform.id=metal
+After=ignition-disks.service
+Before=ignition-files.service
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+ExecStart=sed -i "s/localhost.localdomain/testhost/g"  /sysroot/etc/hostname
+Type=oneshot


### PR DESCRIPTION
Create an azure-hostname.service to fetch the hostname and write to /etc/hostname.

Questions:

1. I feel that this should run before ignition, in case ignition wants to overwrite the file with a static config? I assume this is for DHCP only.

2. This should be firstboot only right?

3. From what little rust I know I think `/usr/bin/afterburn --cmdline --hostname /etc/hostname` is the right call for this

4. I think this needs `systemd network` and that should be it?